### PR TITLE
fixture: fix mismatch for kms-service-dev +  add check to compare if …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ SUDO := $(shell which sudo)
 
 
 
-# used also for key gen
-KMS_DEV_VERSION ?= aa90d98
+# This version must the same as in docker-compose-full.yml
+# TODO add check
+KMS_DEV_VERSION ?= v0.4.5
 
 FHEVM_SOLIDITY_REPO ?= fhevm
 FHEVM_SOLIDITY_PATH ?= $(WORKDIR)/$(FHEVM_SOLIDITY_REPO)

--- a/scripts/copy_fhe_keys.sh
+++ b/scripts/copy_fhe_keys.sh
@@ -22,6 +22,16 @@ DOCKER_IMAGE=ghcr.io/zama-ai/kms-service-dev:"$KMS_DEV_VERSION"
 echo "$DOCKER_IMAGE"
 CURRENT_FOLDER=$PWD
 
+DOCKER_COMPOSE_KMS_VERSION=
+DOCKER_COMPOSE_KMS_VERSION=$(./scripts/get_kms_core_version.sh ./docker-compose/docker-compose-full.yml kms-service-dev)
+
+if [ "$DOCKER_COMPOSE_KMS_VERSION" != "$KMS_DEV_VERSION" ]; then
+    echo "Versions do not match!"
+    echo "DOCKER_COMPOSE_KMS_VERSION in docker-compose-full.yml: $DOCKER_COMPOSE_KMS_VERSION"
+    echo "KMS_DEV_VERSION given to key copy/gen script: $KMS_DEV_VERSION"
+    exit 1
+fi
+
 
 KEYS_FULL_PATH=$CURRENT_FOLDER/res/keys
 mkdir -p $KEYS_FULL_PATH

--- a/scripts/get_kms_core_version.sh
+++ b/scripts/get_kms_core_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if a file name is provided as an argument
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <filename> <docker_image>"
+    exit 1
+fi
+
+# Assign the first argument to a variable
+file="$1"
+docker_image="$2"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+    echo "File does not exist: $file"
+    exit 1
+fi
+
+
+# Extracting the version using grep and awk
+version=$(grep 'ghcr.io/zama-ai/'$docker_image "$file" | awk -F':' '{print $3}' | tr -d '[:space:]')
+
+echo $version

--- a/scripts/prepare_test.sh
+++ b/scripts/prepare_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+make init-ethermint-node
+# Run fhEVM + full KMS components 
+make run-full
+# Deploy ACL, Gateway ..., please wait until the end before testing!!!
+make prepare-e2e-test
+# This test will fail (first event catch is buggy - we are on it)
+make run-async-test

--- a/scripts/prepare_volumes_from_kms_core.sh
+++ b/scripts/prepare_volumes_from_kms_core.sh
@@ -22,6 +22,15 @@ BINARY_NAME="./bin/kms-gen-keys"
 DOCKER_IMAGE=ghcr.io/zama-ai/kms-service-dev:"$KMS_DEV_VERSION"
 CURRENT_FOLDER=$PWD
 
+DOCKER_COMPOSE_KMS_VERSION=$(./scripts/get_kms_core_version.sh ./docker-compose/docker-compose-full.yml kms-service-dev)
+
+if [ "$DOCKER_COMPOSE_KMS_VERSION" != "$KMS_DEV_VERSION" ]; then
+    echo "Versions do not match!"
+    echo "DOCKER_COMPOSE_KMS_VERSION in docker-compose-full.yml: $DOCKER_COMPOSE_KMS_VERSION"
+    echo "KMS_DEV_VERSION given to key copy/gen script: $KMS_DEV_VERSION"
+    exit 1
+fi
+
 
 KEYS_FULL_PATH=$CURRENT_FOLDER/res/keys
 mkdir -p $KEYS_FULL_PATH


### PR DESCRIPTION
…docker version for key gen/copy is the same as KMS backend service