### PR TITLE
docs: removed refs to private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ make e2e-test
 The Zama KMS is not yet audited and should be considered in the early alpha stage. Known bugs and security issues are present as reflected by issue tracking.
 
 #### Parameters
-The default parameters for the Zama KMS are chosen to ensure a failure probability of 2^-64 and symmetric equivalent security of 128 bits.
+The default parameters for the Zama KMS are chosen to ensure a failure probability of 2^-64 and symmetric equivalent security of 132 bits.
 
 #### Side-channel attacks
 


### PR DESCRIPTION
Removes references to repos that are currently private.
This is done since Rand would like to make this repo public soon.
Note that this also means I have removed references to the precompiled docker repos at 
https://github.com/zama-ai/kms/actions/workflows/publish-docker-image.yml 

Also added an update to the parameter description and some minor enhancements to the presentation