### PR TITLE
chore: allow multiple parallel e2e runs when triggered manually

### DIFF
--- a/.github/workflows/fhevm-e2e-tests.yml
+++ b/.github/workflows/fhevm-e2e-tests.yml
@@ -49,7 +49,7 @@ on:
       - "fhevm/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
This should allow any workflow dispatch calls to run in parallel (in case we have several images to test at the same time). Wasn't aware of this `run_id` attribute but it looks like it'll do the work : https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs