### PR TITLE
chore: bump relayer sdk

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@fhevm/solidity": "^0.7.0-3",
         "@openzeppelin/contracts": "^5.3.0",
-        "@zama-fhe/relayer-sdk": "^0.1.0-1",
+        "@zama-fhe/relayer-sdk": "^0.1.0-3",
         "bigint-buffer": "^1.1.5",
         "dotenv": "^16.0.3"
       },
@@ -1878,9 +1878,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.1.0-1",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.1.0-1.tgz",
-      "integrity": "sha512-4ytTpAFZnipY213bRo4xAqMvWyQ3Vy2mx2j6vT2QoASH1537y/7N6lQQy9J2v7KycwCUUkBTTx3/buubANpa/g==",
+      "version": "0.1.0-3",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.1.0-3.tgz",
+      "integrity": "sha512-jwtzq6UIjTFC2GY7rk/1F099PT29G9dEgl60QTtwkooiRbI/qCGX+jUujMPCjoktq+CjTQz3vYC60dA36VUPfA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^11.0.0",
@@ -1888,9 +1888,9 @@
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
         "node-tfhe": "^1.1.2",
-        "node-tkms": "0.11.0-rc13",
+        "node-tkms": "0.11.0-rc15",
         "tfhe": "^1.1.2",
-        "tkms": "0.11.0-rc13",
+        "tkms": "0.11.0-rc15",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -1899,18 +1899,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/@zama-fhe/relayer-sdk/node_modules/node-tkms": {
-      "version": "0.11.0-rc13",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc13.tgz",
-      "integrity": "sha512-ktk2MORlnR6fqodOUPy9uhVP79odztybtIIGIh1fa6AJp9w4Uzs7/+3T0kgmtE7qz2gFS8ycXnkbcbY/1LVaTA==",
-      "license": "BSD-3-Clause-Clear"
-    },
-    "node_modules/@zama-fhe/relayer-sdk/node_modules/tkms": {
-      "version": "0.11.0-rc13",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc13.tgz",
-      "integrity": "sha512-IlEv1+eBH+AmMAC97h62u4oKCEaye/ye0RjcvbywgFiRMw4CdCpKB6bXKa6m5sWsNKTjok0Lrd+v230/PHLGWA==",
-      "license": "BSD-3-Clause-Clear"
     },
     "node_modules/abbrev": {
       "version": "1.0.9",
@@ -5502,6 +5490,12 @@
       "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.1.3.tgz",
       "integrity": "sha512-1gPqD7+aUmOy0zGom9+mCk0IHbnQkUXdvSctVuKG9eT9vOxrX67BnzXcbJLgh7WRiiFJxDobQ9KUdNj1+1gqLQ=="
     },
+    "node_modules/node-tkms": {
+      "version": "0.11.0-rc15",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc15.tgz",
+      "integrity": "sha512-qjJ9fX6kUzFxII0Y3m+oDGlkw+g6pTYweoDBs0KQs8ZEqJtW6bbEkkiS18ZfK+KPdzVyKGdtxCaCS5wdUl/J2A==",
+      "license": "BSD-3-Clause-Clear"
+    },
     "node_modules/nofilter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
@@ -7234,6 +7228,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tkms": {
+      "version": "0.11.0-rc15",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc15.tgz",
+      "integrity": "sha512-ndjb0Kar3S4XmX5B99Bs/QJn74rm01jVYKzNiqnpZe19PCOdUPSkzStgQA6jPodRPtLf3u/ZobD+FVSK+E0DGQ==",
+      "license": "BSD-3-Clause-Clear"
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
     "hardhat": "^2.23.0"
   },
   "dependencies": {
-    "@zama-fhe/relayer-sdk": "^0.1.0-1",
+    "@zama-fhe/relayer-sdk": "^0.1.0-3",
     "@fhevm/solidity": "^0.7.0-3",
     "@openzeppelin/contracts": "^5.3.0",
     "bigint-buffer": "^1.1.5",


### PR DESCRIPTION
The primary goal was to bump node-tkms which is a dependency of relayer-sdk